### PR TITLE
Fix build failures on modern Linuxes

### DIFF
--- a/src/novmm/loader/linux_setup.go
+++ b/src/novmm/loader/linux_setup.go
@@ -20,6 +20,7 @@ package loader
 #include <linux/const.h>
 #include <string.h>
 #include <asm/bootparam.h>
+#include <asm/e820.h>
 
 // E820 codes.
 const int E820Ram = E820_RAM;

--- a/src/novmm/loader/linux_setup.go
+++ b/src/novmm/loader/linux_setup.go
@@ -41,9 +41,9 @@ static inline void e820_set_region(
     __u64 size,
     __u8 type) {
 
-    boot->e820_map[index].addr = start;
-    boot->e820_map[index].size = size;
-    boot->e820_map[index].type = type;
+    boot->e820_table[index].addr = start;
+    boot->e820_table[index].size = size;
+    boot->e820_table[index].type = type;
 }
 static inline void set_header(
     struct boot_params* boot,


### PR DESCRIPTION
A pair of small fixes to address changes in 2012 and 2017.

With these changes, the build succeeds on two systems I tested on:
- SLES 15SP1 with Go 1.11.9
- OpenSUSE 15.1 with Go 1.14.2
